### PR TITLE
tests: Ensure ssh only uses the given identity file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ def ssh_options(sshd, ssh_datadir):
     id_file = ssh_datadir / 'id_rsa'
     return [
         '-i', str(id_file),
+        '-o', 'IdentitiesOnly=yes',
         '-o', 'StrictHostKeyChecking=no',
         '-o', 'UserKnownHostsFile=/dev/null',
     ]


### PR DESCRIPTION
Without this, ssh will happily also try every ssh key in ~/.ssh. If you have a large number of those present, sshd will end up breaking the connection with "Too many authentication failures".

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>