### PR TITLE
receive: Add support for ed25519 signing and verification

### DIFF
--- a/ostree-receive.conf
+++ b/ostree-receive.conf
@@ -22,6 +22,31 @@
 # use the global trusted keyrings in /usr/share/ostree/trusted.gpg.d.
 #gpg_trustedkeys: null
 
+# Signature implementation to use for OSTree's alternative, non-GPG signing
+# system (used by the sign_* keys below). Also affects the format of the
+# "keyfiles" in the subsequent settings.
+# For ed25519 keys, the keyfiles described below should be files consisting of a
+# series of base64-encoded keys, one key per line.
+#sign_type: ed25519
+
+# Keyfiles containing private keys for signing received commits and repo
+# metadata, using the signing system set in sign_type.
+#sign_keyfiles: []
+
+# Whether to verify received commits with the signing system set in sign_type.
+#sign_verify: no
+
+# Keyfile containing public keys for verifying received commits, using the
+# signing system set in sign_type. If null or '', the keyfile at
+# ~/.config/ostree/ostree-receive-trustedkeyfile.SIGNTYPE or
+# /etc/ostree/ostree-receive-trustedkeyfile.SIGNTYPE, where SIGNTYPE is the
+# value of sign_type, will be used.
+# For ed25519 signatures, OSTree will also use the global trusted keyfiles
+# /usr/share/ostree/trusted.ed25519 and /etc/ostree/trusted.ed25519, as well as
+# the keyfiles located within the directories
+# /usr/share/ostree/trusted.ed25519.d and /etc/ostree/trusted.ed25519.d.
+#sign_trustedkeyfile: null
+
 # Update the repo metadata after receiving commits.
 #update: yes
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import yaml
 
 from .util import (
     DATADIR,
+    ED25519_PRIVATE_KEY,
+    ED25519_PUBLIC_KEY,
     PGP_KEY,
     TESTSDIR,
     SRCDIR,
@@ -148,3 +150,17 @@ def gpg_homedir(tmp_path):
     yield homedir
 
     kill_gpg_agent(homedir)
+
+
+@pytest.fixture
+def ed25519_public_keyfile(tmp_path):
+    dest = tmp_path / 'public.ed25519'
+    dest.write_text(ED25519_PUBLIC_KEY)
+    return str(dest)
+
+
+@pytest.fixture
+def ed25519_private_keyfile(tmp_path):
+    dest = tmp_path / 'private.ed25519'
+    dest.write_text(ED25519_PRIVATE_KEY)
+    return str(dest)


### PR DESCRIPTION
This adds support for OSTree's alternate OstreeSign signing system for its ed25519 signature support, as an alternative to GPG signatures.

The new configuration entries rely on ed25519 keys in standalone files, one base64 key per line, for two reasons:

- Pulling *requires* a separate file if you want to use multiple keys, so using separate files everywhere is more consistent.
- Avoiding private keys directly in the file reduces the potential risk of them being revealed by the code.

Additionally, this *does* add support for signing the Flatpak summary, even though upstream does not support ed25519 yet. This is because the current command line options in downstream patches are *identical* to ostree's, so it doesn't actively require any extra effort to support.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>