### PR TITLE
github: Add Arch Linux test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: Arch Base
+            image: archlinux:base
+            setup: |
+              pacman -Sy --noconfirm \
+                base-devel \
+                cairo \
+                flatpak \
+                gobject-introspection \
+                openssh \
+                ostree \
+                python-pip \
+                python-setuptools \
+                python-wheel
+
           - name: Debian Stable
             image: debian:stable-slim
             setup: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,10 @@
 name: Tests
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
This is useful because Arch runs the latest ostree and they enable ed25519 sign support.