### PR TITLE
github: Avoid "This environment is externally managed" failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,6 +143,7 @@ jobs:
     container: ${{ matrix.image }}
     env:
       DEBIAN_FRONTEND: noninteractive
+      PIP_BREAK_SYSTEM_PACKAGES: 1
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The Python PEP-668, shipping since pip 23.0, introduces a big breaking change by forbiding the system-wide installation of Python packages via `pip` to prevent breakage when people try to uninstall OS-provided packages via `pip`, see https://pip.pypa.io/en/stable/news/#v23-0

This concern does not apply to container-based CI systems, so we can bypass it by setting `PIP_BREAK_SYSTEM_PACKAGES=1` before the `pip` call, so that new versions pick it up and older ones ignore it.

See https://peps.python.org/pep-0668/

Resolves: #14