### PR TITLE
Fix Path exception matching on Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,21 @@ jobs:
                 python3-devel \
                 python3-pip
 
+          # Python images are based on Debian stable but should have all
+          # the development tools to build native Python packages.
+          - name: Python 3 Latest
+            image: python:3-slim
+            setup: |
+              apt-get update
+              apt-get -y install \
+                flatpak \
+                gir1.2-ostree-1.0 \
+                libcairo2-dev \
+                libgirepository1.0-dev \
+                openssh-client \
+                openssh-server \
+                ostree
+
           - name: Ubuntu LTS
             image: ubuntu:latest
             setup: |

--- a/tests/test_receive.py
+++ b/tests/test_receive.py
@@ -1026,11 +1026,9 @@ class TestConfig:
         assert expected_log_record in caplog.record_tuples
 
     def test_load_invalid(self, tmp_path):
-        with pytest.raises(receive.OTReceiveConfigError) as excinfo:
+        # Passing a non-path as the config file should fail.
+        with pytest.raises(receive.OTReceiveConfigError, match='PathLike'):
             receive.OTReceiveConfig.load([True])
-        assert str(excinfo.value) == (
-            'expected str, bytes or os.PathLike object, not bool'
-        )
 
         path = tmp_path / 'ostree-receive.conf'
         data = {


### PR DESCRIPTION
The tests currently fail on Python 3.12 since the exception string when initializing a `Path` has changed.

Fixes: #16