### PR TITLE
Handle compatibility with legacy ostree-push

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,3 +6,6 @@ filename =
     ./tests/dumpenv,
     ./tests/ostree-push,
     ./tests/ostree-receive
+
+# Exclude virtualenv.
+extend-exclude = .venv,venv

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 __pycache__
 /.pytest_cache/
 /.tox/
+/.venv/
 /build/
 /dist/
 /ostree_push.egg-info/
+/venv/

--- a/otpush/__init__.py
+++ b/otpush/__init__.py
@@ -1,1 +1,2 @@
 VERSION = '1.1.1'
+MAJOR = VERSION.split('.')[0]

--- a/otpush/push.py
+++ b/otpush/push.py
@@ -69,6 +69,9 @@ logger = logging.getLogger(__name__)
 # Timeout in seconds when waiting for ports or sockets
 RESOURCE_TIMEOUT = 60
 
+# Default remote commands to attempt.
+DEFAULT_COMMANDS = ('ostree-receive',)
+
 
 class OTPushError(Exception):
     """Exceptions from ostree-push"""
@@ -292,11 +295,14 @@ class SSHMultiplexer:
 
 
 def push_refs(local_repo, dest, refs=None, ssh_options=None,
-              command='ostree-receive', dry_run=False):
+              commands=None, dry_run=False):
     """Run ostree-receive on remote with a tunneled HTTP server
 
     Start a local HTTP server and tunnel its port to the remote host.
-    Use this tunneled HTTP server as the URL for ostree_receive().
+    Use this tunneled HTTP server as the URL for ostree_receive(). The
+    remote command to be run is specied as an iterable of strings in the
+    commands argument. If multiple commands are specified, each command
+    is attempted until one is found on the remote host.
     """
     local_repo_path = local_repo.get_path().get_path()
 
@@ -315,6 +321,9 @@ def push_refs(local_repo, dest, refs=None, ssh_options=None,
             raise OTPushError(
                 f'Refs {" ".join(missing_refs)} not found in {local_repo_path}'
             )
+
+    if not commands:
+        commands = DEFAULT_COMMANDS
 
     summary = os.path.join(local_repo_path, 'summary')
     update_summary = False
@@ -351,14 +360,34 @@ def push_refs(local_repo, dest, refs=None, ssh_options=None,
                             http_port, remote_port)
                 remote_url = f'http://127.0.0.1:{remote_port}'
 
-                cmd = shlex.split(command)
-                if dry_run:
-                    cmd.append('-n')
-                cmd += [dest.repo, remote_url]
-                if refs is not None:
-                    cmd += refs
-                logger.debug('Remote command: %s', cmd)
-                ssh.run(cmd)
+                for command in commands:
+                    cmd = shlex.split(command)
+                    if dry_run:
+                        cmd.append('-n')
+                    cmd += [dest.repo, remote_url]
+                    if refs is not None:
+                        cmd += refs
+                    logger.debug('Remote command: %s', cmd)
+                    try:
+                        ssh.run(cmd)
+                        break
+                    except subprocess.CalledProcessError as err:
+                        # Ignore command not found errors to try the
+                        # next command.
+                        if err.returncode != 127:
+                            raise
+
+                        logger.debug(
+                            f'Command {cmd[0]} not found on remote host'
+                        )
+                else:
+                    # None of the commands were found.
+                    cmd_names = " ".join(
+                        [shlex.split(cmd)[0] for cmd in commands]
+                    )
+                    raise OTPushError(
+                        f'Could not find commands {cmd_names} on server'
+                    )
 
 
 PushDest = namedtuple('PushDest', ('host', 'repo', 'user', 'port'))
@@ -498,8 +527,18 @@ class OTPushArgParser(ArgumentParser):
             '--repo',
             help='local repository path (default: current directory)'
         )
-        self.add_argument('--command', default='ostree-receive',
-                          help='remote pull command (default: %(default)s)')
+        self.add_argument(
+            '--command',
+            metavar='COMMAND',
+            dest='commands',
+            action='append',
+            default=None,
+            help=(
+                'remote pull command. Can be specified multiple times to '
+                'attempt commands that may be missing '
+                f'(default: {" ".join(DEFAULT_COMMANDS)})'
+            ),
+        )
         self.add_argument('-i', '-o', metavar='OPTION',
                           action=SSHOptAction,
                           help='options passed through to ssh')
@@ -531,9 +570,14 @@ def main(argv=None):
         repo = OSTree.Repo.new_default()
     repo.open()
 
-    push_refs(repo, args.dest, refs=args.refs,
-              ssh_options=args.ssh_options, command=args.command,
-              dry_run=args.dry_run)
+    push_refs(
+        repo,
+        args.dest,
+        refs=args.refs,
+        ssh_options=args.ssh_options,
+        commands=args.commands,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == '__main__':

--- a/otpush/push.py
+++ b/otpush/push.py
@@ -70,7 +70,8 @@ logger = logging.getLogger(__name__)
 RESOURCE_TIMEOUT = 60
 
 # Default remote commands to attempt.
-DEFAULT_COMMANDS = ('ostree-receive',)
+MAJOR = VERSION.split('.')[0]
+DEFAULT_COMMANDS = (f'ostree-receive-{MAJOR}', 'ostree-receive')
 
 
 class OTPushError(Exception):

--- a/otpush/receive.py
+++ b/otpush/receive.py
@@ -50,6 +50,7 @@ import os
 from pathlib import Path
 import shlex
 import subprocess
+import sys
 from tempfile import TemporaryDirectory
 import yaml
 
@@ -843,6 +844,16 @@ def main():
 
     receiver = OTReceiver(config)
     receiver.receive(args.repo, args.url, args.refs)
+
+
+def compat_main():
+    """Dispatch to legacy main if needed"""
+    # The repo path is an option in legacy receive.
+    if any(arg.startswith('--repo') for arg in sys.argv[1:]):
+        from . import receive_legacy
+        return receive_legacy.main()
+
+    return main()
 
 
 if __name__ == '__main__':

--- a/otpush/receive_legacy.py
+++ b/otpush/receive_legacy.py
@@ -1,0 +1,393 @@
+#!/usr/bin/python3
+
+# ostree-receive-0 - Receive OSTree commits from remote client
+# Copyright (C) 2015  Dan Nicholson <nicholson@endlessm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from argparse import ArgumentParser
+from enum import Enum
+
+import gi
+import logging
+import os
+import sys
+import tempfile
+import shutil
+
+gi.require_version('OSTree', '1.0')
+from gi.repository import GLib, Gio, OSTree  # noqa: E402
+
+PROTO_VERSION = 0
+HEADER_SIZE = 5
+
+
+class PushException(Exception):
+    pass
+
+
+class PushCommandType(Enum):
+    info = 0
+    update = 1
+    putobject = 2
+    status = 3
+    done = 4
+
+
+def msg_byteorder(sys_byteorder=sys.byteorder):
+    if sys_byteorder == 'little':
+        return 'l'
+    elif sys_byteorder == 'big':
+        return 'B'
+    else:
+        raise PushException('Unrecognized system byteorder %s'
+                            % sys_byteorder)
+
+
+def sys_byteorder(msg_byteorder):
+    if msg_byteorder == 'l':
+        return 'little'
+    elif msg_byteorder == 'B':
+        return 'big'
+    else:
+        raise PushException('Unrecognized message byteorder %s'
+                            % msg_byteorder)
+
+
+def ostree_object_path(repo, obj):
+    repodir = repo.get_path().get_path()
+    return os.path.join(repodir, 'objects', obj[0:2], obj[2:])
+
+
+class PushCommand(object):
+    def __init__(self, cmdtype, args):
+        self.cmdtype = cmdtype
+        self.args = args
+        self.validate(self.cmdtype, self.args)
+        self.variant = GLib.Variant('a{sv}', self.args)
+
+    @staticmethod
+    def validate(command, args):
+        if not isinstance(command, PushCommandType):
+            raise PushException('Message command must be PushCommandType')
+        if not isinstance(args, dict):
+            raise PushException('Message args must be dict')
+        # Ensure all values are variants for a{sv} vardict
+        for val in args.values():
+            if not isinstance(val, GLib.Variant):
+                raise PushException('Message args values must be '
+                                    'GLib.Variant')
+
+
+class PushMessageWriter(object):
+    def __init__(self, file, byteorder=sys.byteorder):
+        self.file = file
+        self.byteorder = byteorder
+        self.msg_byteorder = msg_byteorder(self.byteorder)
+
+    def encode_header(self, cmdtype, size):
+        header = self.msg_byteorder.encode() + \
+                 PROTO_VERSION.to_bytes(1, self.byteorder) + \
+                 cmdtype.value.to_bytes(1, self.byteorder) + \
+                 size.to_bytes(2, self.byteorder)
+        return header
+
+    def encode_message(self, command):
+        if not isinstance(command, PushCommand):
+            raise PushException('Command must by GLib.Variant')
+        data = command.variant.get_data_as_bytes()
+        size = data.get_size()
+
+        # Build the header
+        header = self.encode_header(command.cmdtype, size)
+
+        return header + data.get_data()
+
+    def write(self, command):
+        msg = self.encode_message(command)
+        self.file.write(msg)
+        self.file.flush()
+
+    def send_info(self, repo):
+        cmdtype = PushCommandType.info
+        mode = repo.get_mode()
+        _, refs = repo.list_refs(None, None)
+        args = {
+            'mode': GLib.Variant('i', mode),
+            'refs': GLib.Variant('a{ss}', refs)
+        }
+        command = PushCommand(cmdtype, args)
+        self.write(command)
+
+    def send_update(self, refs):
+        cmdtype = PushCommandType.update
+        args = {}
+        for branch, revs in refs.items():
+            args[branch] = GLib.Variant('(ss)', revs)
+        command = PushCommand(cmdtype, args)
+        self.write(command)
+
+    def send_putobject(self, repo, obj):
+        cmdtype = PushCommandType.putobject
+        objpath = ostree_object_path(repo, obj)
+        size = os.stat(objpath).st_size
+        args = {
+            'object': GLib.Variant('s', obj),
+            'size': GLib.Variant('t', size)
+        }
+        command = PushCommand(cmdtype, args)
+        self.write(command)
+
+        # Now write the file after the command
+        logging.info('Sending object {}'.format(obj))
+        logging.debug('Size {} from {}'.format(size, objpath))
+        with open(objpath, 'rb') as objf:
+            remaining = size
+            while remaining > 0:
+                chunk = min(2 ** 20, remaining)
+                buf = objf.read(chunk)
+                logging.debug('Sending {} bytes for {}'
+                              .format(len(buf), obj))
+                self.file.write(buf)
+                self.file.flush()
+                remaining -= chunk
+                logging.debug('{} bytes remaining for {}'
+                              .format(remaining, obj))
+
+    def send_status(self, result, message=''):
+        cmdtype = PushCommandType.status
+        args = {
+            'result': GLib.Variant('b', result),
+            'message': GLib.Variant('s', message)
+        }
+        command = PushCommand(cmdtype, args)
+        self.write(command)
+
+    def send_done(self):
+        command = PushCommand(PushCommandType.done, {})
+        self.write(command)
+
+
+class PushMessageReader(object):
+    def __init__(self, file, byteorder=sys.byteorder, tmpdir=None):
+        self.file = file
+        self.byteorder = byteorder
+        self.tmpdir = tmpdir
+
+    def decode_header(self, header):
+        if len(header) != HEADER_SIZE:
+            raise Exception('Header is %d bytes, not %d'
+                            % (len(header), HEADER_SIZE))
+        order = sys_byteorder(chr(header[0]))
+        version = int(header[1])
+        if version != PROTO_VERSION:
+            raise Exception('Unsupported protocol version %d' % version)
+        cmdtype = PushCommandType(int(header[2]))
+        vlen = int.from_bytes(header[3:], order)
+        return order, version, cmdtype, vlen
+
+    def decode_message(self, message, size, order):
+        if len(message) != size:
+            raise Exception('Expected %d bytes, but got %d'
+                            % (size, len(message)))
+        data = GLib.Bytes.new(message)
+        variant = GLib.Variant.new_from_bytes(GLib.VariantType.new('a{sv}'),
+                                              data, False)
+        if order != self.byteorder:
+            variant = GLib.Variant.byteswap(variant)
+
+        return variant
+
+    def read(self):
+        header = self.file.read(HEADER_SIZE)
+        if len(header) == 0:
+            # Remote end quit
+            return None, None
+        order, version, cmdtype, size = self.decode_header(header)
+        msg = self.file.read(size)
+        if len(msg) != size:
+            raise PushException('Did not receive full message')
+        args = self.decode_message(msg, size, order)
+
+        return cmdtype, args
+
+    def receive(self, allowed):
+        cmdtype, args = self.read()
+        if cmdtype is None:
+            raise PushException('Expected reply, got none')
+        if cmdtype not in allowed:
+            raise PushException('Unexpected reply type', cmdtype.name)
+        return cmdtype, args.unpack()
+
+    def receive_info(self):
+        cmdtype, args = self.receive([PushCommandType.info])
+        return args
+
+    def receive_update(self):
+        cmdtype, args = self.receive([PushCommandType.update])
+        return args
+
+    def receive_putobject_data(self, repo, args):
+        # Read in the object and store it in the tmp directory
+        obj = args['object']
+        size = args['size']
+        tmppath = os.path.join(self.tmpdir, obj)
+        logging.info('Receiving object {}'.format(obj))
+        logging.debug('Size {} to {}'.format(size, tmppath))
+        with open(tmppath, 'wb') as tmpf:
+            remaining = size
+            while remaining > 0:
+                chunk = min(2 ** 20, remaining)
+                buf = self.file.read(chunk)
+                logging.debug('Receiving {} bytes for {}'
+                              .format(len(buf), obj))
+                tmpf.write(buf)
+                remaining -= chunk
+                logging.debug('{} bytes remaining for {}'
+                              .format(remaining, obj))
+
+    def receive_putobject(self, repo):
+        cmdtype, args = self.receive([PushCommandType.putobject])
+        self.receive_putobject_data(repo, args)
+        return args
+
+    def receive_status(self):
+        cmdtype, args = self.receive([PushCommandType.status])
+        return args
+
+    def receive_done(self):
+        cmdtype, args = self.receive([PushCommandType.done])
+        return args
+
+
+class OSTreeReceiver(object):
+    def __init__(self, repopath):
+        self.repopath = repopath
+
+        if self.repopath is None:
+            self.repo = OSTree.Repo.new_default()
+        else:
+            self.repo = OSTree.Repo.new(Gio.File.new_for_path(self.repopath))
+        self.repo.open(None)
+
+        repo_tmp = os.path.join(self.repopath, 'tmp')
+        self.tmpdir = tempfile.mkdtemp(dir=repo_tmp, prefix='ostree-push-')
+        self.writer = PushMessageWriter(sys.stdout.buffer)
+        self.reader = PushMessageReader(sys.stdin.buffer, tmpdir=self.tmpdir)
+
+        # Set a sane umask before writing any objects
+        os.umask(0o0022)
+
+    def close(self):
+        shutil.rmtree(self.tmpdir)
+        sys.stdout.close()
+        return 0
+
+    def run(self):
+        try:
+            return self.do_run()
+        except PushException:
+            # Ensure we cleanup files if there was an error
+            self.close()
+            raise
+
+    def do_run(self):
+        # Send info immediately
+        self.writer.send_info(self.repo)
+
+        # Wait for update or done command
+        cmdtype, args = self.reader.receive([PushCommandType.update,
+                                             PushCommandType.done])
+        if cmdtype == PushCommandType.done:
+            return 0
+        update_refs = args
+        for branch, revs in update_refs.items():
+            # Check that each branch can be updated appropriately
+            _, current = self.repo.resolve_rev(branch, True)
+            if current is None:
+                # From commit should be all 0s
+                if revs[0] != '0' * 64:
+                    self.writer.send_status(False,
+                                            'Invalid from commit %s '
+                                            'for new branch %s'
+                                            % (revs[0], branch))
+                    self.reader.receive_done()
+                    return 1
+            elif revs[0] != current:
+                self.writer.send_status(False,
+                                        'Branch %s is at %s, not %s'
+                                        % (branch, current, revs[0]))
+                self.reader.receive_done()
+                return 1
+
+        # All updates valid
+        self.writer.send_status(True)
+
+        # Wait for putobject or done command
+        received_objects = []
+        while True:
+            cmdtype, args = self.reader.receive([PushCommandType.putobject,
+                                                 PushCommandType.done])
+            if cmdtype == PushCommandType.done:
+                logging.debug('Received done, exiting putobject loop')
+                break
+
+            self.reader.receive_putobject_data(self.repo, args)
+            received_objects.append(args['object'])
+            self.writer.send_status(True)
+
+        # If we didn't get any objects, we're done
+        if len(received_objects) == 0:
+            return 0
+
+        # Got all objects, move them to the object store
+        for obj in received_objects:
+            tmp_path = os.path.join(self.tmpdir, obj)
+            obj_path = ostree_object_path(self.repo, obj)
+            os.makedirs(os.path.dirname(obj_path), exist_ok=True)
+            logging.debug('Renaming {} to {}'.format(tmp_path, obj_path))
+            os.rename(tmp_path, obj_path)
+
+        # Finally, update the refs
+        for branch, revs in update_refs.items():
+            logging.debug('Setting ref {} to {}'.format(branch, revs[1]))
+            self.repo.set_ref_immediate(None, branch, revs[1], None)
+
+        return 0
+
+
+def main():
+    aparser = ArgumentParser(description='Receive pushed ostree objects')
+    aparser.add_argument('--repo', help='repository path')
+    aparser.add_argument('-v', '--verbose', action='store_true',
+                         help='enable verbose output')
+    aparser.add_argument('--debug', action='store_true',
+                         help='enable debugging output')
+    args = aparser.parse_args()
+
+    loglevel = logging.WARNING
+    if args.verbose:
+        loglevel = logging.INFO
+    if args.debug:
+        loglevel = logging.DEBUG
+    logging.basicConfig(format='%(module)s: %(levelname)s: %(message)s',
+                        level=loglevel, stream=sys.stderr)
+
+    receiver = OSTreeReceiver(args.repo)
+    return receiver.run()
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/scripts/ostree-receive-shell
+++ b/scripts/ostree-receive-shell
@@ -34,7 +34,9 @@ import os
 import shlex
 import sys
 
-ALLOWED_COMMAND = 'ostree-receive'
+# Allow all possible ostree-receive installed names. Remember to add to
+# this tuple when bumping the major version.
+ALLOWED_COMMANDS = ('ostree-receive-1', 'ostree-receive')
 PROG = os.path.basename(__file__)
 BINDIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -50,7 +52,7 @@ elif argc != 3 or sys.argv[1] != '-c':
 
 # Make sure required command has been specified.
 args = shlex.split(sys.argv[2])
-if args[0] != ALLOWED_COMMAND:
+if args[0] not in ALLOWED_COMMANDS:
     print(f'{PROG}: Executing {args[0]} not allowed',  file=sys.stderr)
     sys.exit(1)
 

--- a/scripts/ostree-receive-shell
+++ b/scripts/ostree-receive-shell
@@ -36,7 +36,11 @@ import sys
 
 # Allow all possible ostree-receive installed names. Remember to add to
 # this tuple when bumping the major version.
-ALLOWED_COMMANDS = ('ostree-receive-1', 'ostree-receive')
+ALLOWED_COMMANDS = (
+    'ostree-receive-1',
+    'ostree-receive-0',
+    'ostree-receive',
+)
 PROG = os.path.basename(__file__)
 BINDIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,6 @@ python_requires = >=3.7
 console_scripts =
   ostree-push = otpush.push:main
   ostree-receive = otpush.receive:main
+  # Keep this suffix in sync with the major version. When changing it,
+  # add the updated name to the list of receive shell allowed commands.
+  ostree-receive-1 = otpush.receive:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,3 +36,5 @@ console_scripts =
   # Keep this suffix in sync with the major version. When changing it,
   # add the updated name to the list of receive shell allowed commands.
   ostree-receive-1 = otpush.receive:main
+  # FIXME: Delete this after giving time to migrate clients.
+  ostree-receive-0 = otpush.receive_legacy:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ python_requires = >=3.7
 [options.entry_points]
 console_scripts =
   ostree-push = otpush.push:main
-  ostree-receive = otpush.receive:main
+  ostree-receive = otpush.receive:compat_main
   # Keep this suffix in sync with the major version. When changing it,
   # add the updated name to the list of receive shell allowed commands.
   ostree-receive-1 = otpush.receive:main

--- a/tests/ostree-receive
+++ b/tests/ostree-receive
@@ -11,4 +11,4 @@ logger.debug('sys.path=%s', ':'.join(sys.path))
 logger.debug('sys.argv=%s', sys.argv)
 
 from otpush import receive  # noqa: E402
-receive.main()
+sys.exit(receive.compat_main())

--- a/tests/ostree-receive-0
+++ b/tests/ostree-receive-0
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# ostree-receive-0 script for testing
+
+import logging
+import sys
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger('tests/ostree-receive-0')
+logger.debug('sys.path=%s', ':'.join(sys.path))
+logger.debug('sys.argv=%s', sys.argv)
+
+from otpush import receive_legacy  # noqa: E402
+sys.exit(receive_legacy.main())

--- a/tests/ostree-receive-1
+++ b/tests/ostree-receive-1
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# ostree-receive-1 script for testing
+
+import logging
+import sys
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger('tests/ostree-receive-1')
+logger.debug('sys.path=%s', ':'.join(sys.path))
+logger.debug('sys.argv=%s', sys.argv)
+
+from otpush import receive  # noqa: E402
+receive.main()

--- a/tests/test_receive_legacy.py
+++ b/tests/test_receive_legacy.py
@@ -1,0 +1,144 @@
+# Tests for receive_legacy/ostree-receive-0.
+
+from contextlib import contextmanager
+import gi
+import logging
+import os
+import subprocess
+
+from otpush.receive_legacy import (
+    PushMessageReader,
+    PushMessageWriter,
+    ostree_object_path,
+)
+
+from .util import random_commit
+
+gi.require_version('OSTree', '1.0')
+from gi.repository import OSTree  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def run_receive(
+    dest_repo,
+    env_vars,
+    check=True,
+    command='ostree-receive-0',
+    options=None,
+):
+    """Run ostree-receive-0 and return reader/writer buffers
+
+    The receiver needs to run in a subprocess since it uses sys.stdin/stdout
+    directly and that interacts poorly with pytest.
+    """
+    # Start the receiver with pipes for stdin and stdout to use for the
+    # protocol.
+    env = os.environ.copy()
+    if env_vars:
+        env.update(env_vars)
+    options = options or []
+    cmd = [command, '--debug', f'--repo={dest_repo.path}'] + options
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+
+    # Create a reader and writer and yield them to the caller.
+    reader = PushMessageReader(proc.stdout)
+    writer = PushMessageWriter(proc.stdin)
+    yield reader, writer
+
+    # Make sure the process exits. This is basically how subprocess.run()
+    # cleans up.
+    try:
+        out, _ = proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        logger.warning(f'{cmd} did not exit, killing it')
+        proc.kill()
+        proc.wait()
+        raise
+    except:  # noqa: E722
+        logger.warning(f'Exception stopping {cmd}, killing it')
+        proc.kill()
+        raise
+
+    if check:
+        ret = proc.poll()
+        assert ret == 0
+    assert out == b''
+
+
+def test_noop(dest_repo, cli_env_vars):
+    """Basic protocol smoketest"""
+    with run_receive(dest_repo, cli_env_vars) as (reader, writer):
+        data = reader.receive_info()
+        assert data['mode'] == OSTree.RepoMode.ARCHIVE_Z2
+        assert data['refs'] == {}
+        writer.send_done()
+
+
+def commit_objects_iter(repo, rev):
+    """Get the path for all objects referenced by a commit"""
+    _, reachable = repo.traverse_commit(rev, 0, None)
+    for obj in reachable:
+        objname = OSTree.object_to_string(obj[0], obj[1])
+        if obj[1] == OSTree.ObjectType.FILE:
+            # Make this a filez since we're archive-z2
+            objname += 'z'
+        elif obj[1] == OSTree.ObjectType.COMMIT:
+            # Add in detached metadata
+            metaobj = objname + 'meta'
+            metapath = ostree_object_path(repo, metaobj)
+            if os.path.exists(metapath):
+                yield metaobj
+        yield objname
+
+
+def test_update(dest_repo, cli_env_vars, source_repo, tmp_files_path):
+    """Test the update and putobject commands"""
+    rev = random_commit(source_repo, tmp_files_path, 'test')
+
+    # Try to update with an invalid from_rev.
+    with run_receive(dest_repo, cli_env_vars, check=False) as (reader, writer):
+        data = reader.receive_info()
+        assert data['refs'] == {}
+
+        # There's no remote commit, so from_rev should be all 0s.
+        from_rev = '1' * 64
+        update_refs = {'test': (from_rev, rev)}
+        writer.send_update(update_refs)
+        data = reader.receive_status()
+        assert not data['result']
+        assert data['message'].startswith('Invalid from commit')
+
+        writer.send_done()
+
+    # Send the update correctly.
+    with run_receive(dest_repo, cli_env_vars) as (reader, writer):
+        data = reader.receive_info()
+        assert data['refs'] == {}
+
+        from_rev = '0' * 64
+        update_refs = {'test': (from_rev, rev)}
+        writer.send_update(update_refs)
+        data = reader.receive_status()
+        assert data['result']
+
+        for obj in set(commit_objects_iter(source_repo, rev)):
+            writer.send_putobject(source_repo, obj)
+            data = reader.receive_status()
+            assert data['result']
+
+        writer.send_done()
+
+    # The destination repo should now have the commit and ref.
+    _, dest_refs = dest_repo.list_refs()
+    assert dest_refs == {'test': rev}
+    with run_receive(dest_repo, cli_env_vars) as (reader, writer):
+        data = reader.receive_info()
+        assert data['refs'] == {'test': rev}
+        writer.send_done()

--- a/tests/test_receive_shell.py
+++ b/tests/test_receive_shell.py
@@ -4,15 +4,20 @@ import pytest
 import shutil
 import subprocess
 
+from otpush import VERSION
+
 from .util import SCRIPTSDIR, TESTSDIR
 
 shell_abspath = os.path.join(SCRIPTSDIR, 'ostree-receive-shell')
 dumpenv_abspath = os.path.join(TESTSDIR, 'dumpenv')
 
+MAJOR = VERSION.split('.')[0]
+ostree_receive_versioned = f'ostree-receive-{MAJOR}'
+
 # Some tests can't be run if ostree-receive is in PATH
 skip_ostree_receive_in_path = pytest.mark.skipif(
-    shutil.which('ostree-receive') is not None,
-    reason="cannot test correctly with ostree-receive in PATH"
+    shutil.which(ostree_receive_versioned) is not None,
+    reason=f'cannot test correctly with {ostree_receive_versioned} in PATH',
 )
 
 
@@ -27,7 +32,7 @@ def tmp_bindir(tmp_path):
 @pytest.fixture
 def tmp_receive(tmp_bindir):
     """Copy dumpenv to a temporary ostree-receive"""
-    receive = tmp_bindir / 'ostree-receive'
+    receive = tmp_bindir / ostree_receive_versioned
     shutil.copy(dumpenv_abspath, receive)
     os.chmod(receive, 0o755)
     return receive
@@ -54,13 +59,13 @@ def shell_env_vars(tmp_bindir):
 
 def test_command_args(shell_env_vars, tmp_shell, tmp_receive):
     """Test how arguments are passed to ostree-receive"""
-    cmd = ('ostree-receive-shell', '-c', 'ostree-receive')
+    cmd = ('ostree-receive-shell', '-c', tmp_receive.name)
     proc = subprocess.run(cmd, check=True, env=shell_env_vars,
                           stdout=subprocess.PIPE)
     data = json.loads(proc.stdout.decode('utf-8'))
     assert data['args'] == [str(tmp_receive)]
 
-    cmd = ('ostree-receive-shell', '-c', 'ostree-receive -n foo bar')
+    cmd = ('ostree-receive-shell', '-c', f'{tmp_receive.name} -n foo bar')
     proc = subprocess.run(cmd, check=True, env=shell_env_vars,
                           stdout=subprocess.PIPE)
     data = json.loads(proc.stdout.decode('utf-8'))
@@ -71,7 +76,7 @@ def test_auto_path(shell_env_vars, tmp_receive):
     """Test that the shell's directory is appended to PATH"""
     # Here we use the shell in the source directory to ensure that it's
     # directory isn't in PATH. Otherwise it won't get appended.
-    cmd = (shell_abspath, '-c', 'ostree-receive')
+    cmd = (shell_abspath, '-c', tmp_receive.name)
     proc = subprocess.run(cmd, check=True, env=shell_env_vars,
                           stdout=subprocess.PIPE)
     data = json.loads(proc.stdout.decode('utf-8'))
@@ -107,12 +112,27 @@ def test_wrong_args():
         )
 
 
-def test_bad_command():
-    """Test when disallowed commands are requested"""
+def test_allowed_commands(shell_env_vars, tmp_shell, tmp_bindir):
+    """Test when allowed and disallowed commands are requested"""
+    # Allowed commands
+    allowed = (ostree_receive_versioned, 'ostree-receive')
+    for name in allowed:
+        cmd = (shell_abspath, '-c', name)
+        receive = tmp_bindir / name
+        shutil.copy(dumpenv_abspath, receive)
+        os.chmod(receive, 0o755)
+        proc = subprocess.run(cmd, check=True, env=shell_env_vars,
+                              stdout=subprocess.PIPE)
+        data = json.loads(proc.stdout.decode('utf-8'))
+        assert data['args'] == [str(receive)]
+
+    # Disallowed commands
     arguments = (
         ('foo',),
         ('foo', 'bar'),
+        (f'/usr/bin/{ostree_receive_versioned}'),
         ('/usr/bin/ostree-receive'),
+        (f'ostree-receive-{int(MAJOR) + 1}'),
     )
     for args in arguments:
         cmd = (shell_abspath, '-c', ' '.join(args))
@@ -130,7 +150,7 @@ def test_bad_command():
 @skip_ostree_receive_in_path
 def test_exec_errors(shell_env_vars, tmp_shell, tmp_receive, tmp_path):
     """Test how errors from execve are handled"""
-    cmd = ('ostree-receive-shell', '-c', 'ostree-receive')
+    cmd = ('ostree-receive-shell', '-c', tmp_receive.name)
 
     # Make the temporary ostree-receive non-executable to get a
     # permission denied error.
@@ -138,7 +158,7 @@ def test_exec_errors(shell_env_vars, tmp_shell, tmp_receive, tmp_path):
     proc = subprocess.run(cmd, env=shell_env_vars, stderr=subprocess.PIPE)
     assert proc.returncode == 126
     assert proc.stderr.decode('utf-8') == (
-        'ostree-receive-shell: ostree-receive: Permission denied\n'
+        f'ostree-receive-shell: {tmp_receive.name}: Permission denied\n'
     )
 
     # Make the temporary ostree-receive into a dangling symlink to get a
@@ -148,5 +168,6 @@ def test_exec_errors(shell_env_vars, tmp_shell, tmp_receive, tmp_path):
     proc = subprocess.run(cmd, env=shell_env_vars, stderr=subprocess.PIPE)
     assert proc.returncode == 127
     assert proc.stderr.decode('utf-8') == (
-        'ostree-receive-shell: ostree-receive: No such file or directory\n'
+        f'ostree-receive-shell: {tmp_receive.name}: '
+        'No such file or directory\n'
     )

--- a/tests/test_receive_shell.py
+++ b/tests/test_receive_shell.py
@@ -115,7 +115,9 @@ def test_wrong_args():
 def test_allowed_commands(shell_env_vars, tmp_shell, tmp_bindir):
     """Test when allowed and disallowed commands are requested"""
     # Allowed commands
-    allowed = (ostree_receive_versioned, 'ostree-receive')
+    allowed = [
+        f'ostree-receive-{major}' for major in range(int(MAJOR) + 1)
+    ] + ['ostree-receive']
     for name in allowed:
         cmd = (shell_abspath, '-c', name)
         receive = tmp_bindir / name


### PR DESCRIPTION
There are deployments using the legacy protocol based push/receive architecture. Unless the client and server are updated simultaneously in these deployments, pushes will be broken since the interface is the single `ostree-receive` program on the server.

In order to maintain compatibility, the following changes are made:

* The receive entry point is available as both `ostree-receive-1` and `ostree-receive`. This way the current receive interface is available unambiguously.
* The push side attempts `ostree-receive-1` before falling back to `ostree-receive` if `ostree-receive-1` isn't found. This is to keep deployments already using the new architecture if clients are updated before the server.
* The legacy receive code is brought back as `ostree-receive-0`. No updates or bug fixes will be made to this code. It is there only to allow deployments with the legacy architecture to transition to the new architecture.
* The unversioned `ostree-receive` entry point will detect if the client is attempting to use the legacy receive and dispatch to that code as needed.

At some point in the future, the legacy receive code and the compatibility layer will be dropped.

This is basically a different implementation of @em-'s #12.

Fixes: #11